### PR TITLE
feat: 登入頁面前後端分離

### DIFF
--- a/src/components/layout/AppNavbar.vue
+++ b/src/components/layout/AppNavbar.vue
@@ -34,8 +34,18 @@
                   class="text-black font-medium px-4 py-2 hover:text-primary"
                   >住宿</RouterLink
                 >
+                <RouterLink
+                  to="/hotels"
+                  class="text-black font-medium px-4 py-2 hover:text-primary"
+                  >住宿</RouterLink
+                >
               </li>
               <li>
+                <RouterLink
+                  to="/tickets"
+                  class="text-black font-medium px-4 py-2 hover:text-primary"
+                  >體驗</RouterLink
+                >
                 <RouterLink
                   to="/tickets"
                   class="text-black font-medium px-4 py-2 hover:text-primary"
@@ -48,8 +58,18 @@
                   class="text-black font-medium px-4 py-2 hover:text-primary"
                   >比較</RouterLink
                 >
+                <RouterLink
+                  to="/hotels/compare"
+                  class="text-black font-medium px-4 py-2 hover:text-primary"
+                  >比較</RouterLink
+                >
               </li>
               <li>
+                <RouterLink
+                  to="/travel-dna/intro"
+                  class="text-black font-medium px-4 py-2 hover:text-primary"
+                  >旅行DNA</RouterLink
+                >
                 <RouterLink
                   to="/travel-dna/intro"
                   class="text-black font-medium px-4 py-2 hover:text-primary"
@@ -67,11 +87,19 @@
               class="hidden md:block text-black font-medium px-4 py-2 hover:text-primary"
               >常見問題</RouterLink
             >
+            <RouterLink
+              to="/support"
+              class="hidden md:block text-black font-medium px-4 py-2 hover:text-primary"
+              >常見問題</RouterLink
+            >
           </li>
+
 
           <li>
             <!-- 未登入 -->
+            <!-- 未登入 -->
             <button
+              v-if="!auth.isLoggedIn"
               v-if="!auth.isLoggedIn"
               type="button"
               class="text-white rounded-[20px] bg-primary px-4 py-2 border border-white/15 hover:bg-[#455A71]"
@@ -88,7 +116,7 @@
                 @click="toggleUserMenu"
               >
                 <span class="max-w-[160px] truncate">
-                  {{ auth.profile?.full_name || auth.user?.email || '會員' }}
+                  {{ auth.user?.full_name || auth.user?.email || '會員' }}
                 </span>
 
                 <svg
@@ -134,7 +162,6 @@
       </div>
     </nav>
   </header>
-
   <nav class="block md:hidden fixed w-full z-50 bottom-5 h-16 mx-auto pointer-events-auto">
     <ul
       class="flex flex-row justify-between items-center mx-5 p-1 rounded-full bg-white/80 backdrop-blur-md border border-white/45 pointer-events-auto"
@@ -156,7 +183,6 @@
             <span class="text-xs">{{ item.name }}</span>
           </li>
         </RouterLink>
-
         <li
           v-else
           @click="isOpen = true"
@@ -170,7 +196,6 @@
       </template>
     </ul>
   </nav>
-
   <div class="relative z-[100]">
     <Transition
       enter-active-class="transition-opacity ease-linear duration-300"
@@ -182,7 +207,6 @@
     >
       <div v-if="isOpen" @click="isOpen = false" class="fixed inset-0 bg-black/25 backdrop-blur-sm"></div>
     </Transition>
-
     <Transition
       enter-active-class="transition-transform ease-in-out duration-300"
       enter-from-class="translate-x-full"
@@ -200,8 +224,10 @@
           <button @click="isOpen = false" class="text-gray-500 text-2xl">&times;</button>
         </div>
 
+
         <nav class="flex flex-col gap-4">
           <button
+            v-if="!auth.isLoggedIn"
             v-if="!auth.isLoggedIn"
             type="button"
             class="text-left text-black font-medium border-b border-primary/25 pb-2"
@@ -216,7 +242,7 @@
               class="text-black font-medium hover:text-primary"
               @click="goProfile(); isOpen = false"
             >
-              {{ auth.profile?.full_name || auth.user?.email }}
+            {{ auth.user?.full_name || auth.user?.email || '會員' }}
             </button>
 
             <button
@@ -254,7 +280,6 @@
       </div>
     </Transition>
   </div>
-
   <LoginModal
     v-model="isLoginModalOpen"
     @login="handleLogin"
@@ -262,7 +287,6 @@
     @forgot-password="handleForgotPassword"
     @social="handleSocial"
   />
-
   <RegisterModal
     v-model="isRegisterModalOpen"
     @go-login="openLoginFromRegister"
@@ -281,6 +305,9 @@ const router = useRouter()
 const route = useRoute()
 const auth = useAuthStore()
 
+const router = useRouter()
+const route = useRoute()
+const auth = useAuthStore()
 const isOpen = ref(false)
 const isLoginModalOpen = ref(false)
 const isRegisterModalOpen = ref(false)
@@ -305,54 +332,42 @@ const openLogin = () => {
   isRegisterModalOpen.value = false
   isLoginModalOpen.value = true
 }
-
 const openRegister = () => {
   isLoginModalOpen.value = false
   isRegisterModalOpen.value = true
 }
-
 const openLoginFromRegister = () => {
   isRegisterModalOpen.value = false
   isLoginModalOpen.value = true
 }
-
 const handleLogout = async () => {
   isUserMenuOpen.value = false
   isOpen.value = false
   await auth.logout()
   router.push('/')
 }
-
 const onDocClick = (e: MouseEvent) => {
   if (!isUserMenuOpen.value) return
-
   const target = e.target as HTMLElement | null
   if (!target) return
-
   if (target.closest('[data-user-menu]')) return
-
   isUserMenuOpen.value = false
 }
-
 const closeAllAuthModal = () => {
   isLoginModalOpen.value = false
   isRegisterModalOpen.value = false
 }
-
-const handleLogin = async ({ user }: { user: any }) => {
-  await auth.setAuth(user)
+const handleLogin = ({ user }: { user: any }) => {
+  auth.setAuth(user)
   isLoginModalOpen.value = false
 }
-
 const handleSignup = () => {
   isLoginModalOpen.value = false
   openRegister()
 }
-
 const handleForgotPassword = () => {
   isLoginModalOpen.value = false
 }
-
 const handleSocial = (provider: 'google' | 'apple' | 'line') => {
   console.log('social login:', provider)
 }
@@ -398,7 +413,11 @@ const navItems = [
 ]
 
 onMounted(async () => {
-  await auth.init()
+  try {
+    await auth.init()
+  } catch (e) {
+    console.warn('[auth.init] failed:', e)
+  }
   document.addEventListener('click', onDocClick)
 })
 

--- a/src/services/authApi.ts
+++ b/src/services/authApi.ts
@@ -1,0 +1,33 @@
+const API = import.meta.env.VITE_API_BASE_URL
+
+export type SessionUser = {
+  id: string
+  email: string | null
+}
+
+export async function exchangeToCookie(access_token: string) {
+  const r = await fetch(`${API}/auth/session`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    credentials: 'include',
+    body: JSON.stringify({ access_token }),
+  })
+
+  const data = await r.json().catch(() => ({}))
+  if (!r.ok) throw new Error(data?.message || 'session create failed')
+
+  return data as { ok: true; user: SessionUser }
+}
+
+export async function me() {
+  const r = await fetch(`${API}/auth/me`, { credentials: 'include' })
+  const data = await r.json().catch(() => ({}))
+  return data as { user: SessionUser | null }
+}
+
+export async function logoutApi() {
+  const r = await fetch(`${API}/auth/logout`, { method: 'POST', credentials: 'include' })
+  const data = await r.json().catch(() => ({}))
+  if (!r.ok) throw new Error(data?.message || 'logout failed')
+  return data as { ok: true }
+}

--- a/src/stores/auth.ts
+++ b/src/stores/auth.ts
@@ -1,55 +1,38 @@
 import { defineStore } from 'pinia'
 import { ref, computed } from 'vue'
+import { me, logoutApi, type SessionUser } from '@/services/authApi'
 import { supabase } from '@/utils/supabaseClient'
 
 export const useAuthStore = defineStore('auth', () => {
-  const user = ref(null)
-  const profile = ref(null)
+  const user = ref<SessionUser | null>(null)
   const loading = ref(false)
+  const ready = ref(false)
 
   const isLoggedIn = computed(() => !!user.value)
 
-  // 🔹 初始化（頁面重整時呼叫）
+  // ✅ 初始化：用後端 cookie /me
   const init = async () => {
     loading.value = true
     try {
-      const { data } = await supabase.auth.getSession()
-      user.value = data.session?.user ?? null
-
-      if (user.value) {
-        const { data: p } = await supabase
-          .from('profiles')
-          .select('*')
-          .eq('id', user.value.id)
-          .single()
-        profile.value = p
-      }
+      const res = await me()
+      user.value = res.user
     } finally {
       loading.value = false
+      ready.value = true
     }
   }
 
-  // 🔹 登入後呼叫
-  const setAuth = async (newUser) => {
+  // ✅ 登入後：直接塞後端 user（LoginModal emit 的就是這個）
+  const setAuth = (newUser: SessionUser | null) => {
     user.value = newUser
-    if (newUser) {
-      const { data: p } = await supabase
-        .from('profiles')
-        .select('*')
-        .eq('id', newUser.id)
-        .single()
-      profile.value = p
-    } else {
-      profile.value = null
-    }
   }
 
-  // 🔹 登出
+  // ✅ 登出：清 cookie + 清 supabase session（保險）
   const logout = async () => {
+    await logoutApi()
     await supabase.auth.signOut()
     user.value = null
-    profile.value = null
   }
 
-  return { user, profile, isLoggedIn, loading, init, setAuth, logout }
+  return { user, isLoggedIn, loading, ready, init, setAuth, logout }
 })

--- a/src/views/user/LoginModel.vue
+++ b/src/views/user/LoginModel.vue
@@ -9,7 +9,6 @@
         @keydown.esc="close"
         tabindex="-1"
       >
-        <!-- overlay -->
         <div class="absolute inset-0 bg-black/60 backdrop-blur-sm" @click="close" />
 
         <!-- modal card -->
@@ -211,9 +210,7 @@
                   alt="Taipei 101"
                   class="absolute inset-0 h-full w-full object-cover"
                 />
-
                 <div class="absolute inset-0 bg-black/10"></div>
-
                 <div class="absolute left-6 top-6 text-left text-white drop-shadow">
                   <div class="text-3xl font-semibold leading-none">台北101</div>
                   <div class="text-sm opacity-90">Taipei 101</div>
@@ -239,6 +236,8 @@
 <script setup lang="ts">
 import { watch, ref, onUnmounted } from 'vue'
 import { supabase } from '@/utils/supabaseClient'
+import { exchangeToCookie, me } from '@/services/authApi'
+import type { SessionUser } from '@/services/authApi'
 
 const props = defineProps({
   modelValue: { type: Boolean, default: false },
@@ -251,7 +250,7 @@ const props = defineProps({
 
 const emit = defineEmits<{
   (e: 'update:modelValue', v: boolean): void
-  (e: 'login', payload: { user: any }): void
+  (e: 'login', payload: { user: SessionUser }): void
   (e: 'signup'): void
   (e: 'forgot-password'): void
   (e: 'social', provider: 'google' | 'apple' | 'line'): void
@@ -267,22 +266,22 @@ const onSubmit = async () => {
   try {
     if (!email.value || !password.value) throw new Error('請輸入 email 與密碼')
 
-    const { data, error } = await supabase.auth.signInWithPassword({
+    const { data: signInData, error: signInError } = await supabase.auth.signInWithPassword({
       email: email.value,
       password: password.value,
     })
+    if (signInError) throw signInError
 
-    if (error) {
-      console.error('[login] error:', error)
-      alert(error.message)
-      return
-    }
+    const access_token = signInData.session?.access_token
+    if (!access_token) throw new Error('No access token')
 
-    const user = data?.user
-    if (!user) throw new Error('登入失敗：沒有取得 user 資料')
+    await exchangeToCookie(access_token)
 
-    emit('login', { user })
+    const meRes = await me()
 
+    if (!meRes?.user) throw new Error('登入失敗：cookie session 未建立')
+
+    emit('login', { user: meRes.user })
     emit('update:modelValue', false)
   } catch (err: any) {
     console.error('[login] error:', err)


### PR DESCRIPTION
新增 auth 路由：提供前端用 Supabase access_token 換取後端 HttpOnly cookie session

後端用 jwt 產生/驗證 session token，cookie 名稱預設 wantrip_session

/api/auth/session 與 /api/auth/exchange 共用同一套 handler（相容舊路由）

建立 session 時同步 upsert profiles（確保登入/註冊後 profiles 一定存在）

新增：

GET /api/auth/me：讀 cookie 驗證登入狀態並回傳 user

POST /api/auth/logout：清除 session cookie

GET /api/auth/cors-test：CORS 測試用

為什麼要做

前端不需要把 token 存 localStorage

用 HttpOnly cookie 避免 XSS 直接讀取 token

後端 API 可以直接使用 cookie 做身份驗證（之後擴充更方便）

環境變數需求

APP_JWT_SECRET：後端 session JWT 的 secret（必填）

FRONTEND_ORIGIN：前端 origin（預設 http://localhost:5173）

COOKIE_NAME：cookie 名稱（預設 wantrip_session）

測試方式

登入後：

POST /api/auth/session with { access_token } 應回 { ok: true, user: { id, email } }，並寫入 cookie

GET /api/auth/me 應回 { user: { id, email } }

登出後：

POST /api/auth/logout 清 cookie

GET /api/auth/me 回 { user: null }