### PR TITLE
feat:會員中心修改密碼

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,8 @@
         "pinia": "^3.0.4",
         "v-calendar": "^3.1.2",
         "vue": "^3.5.25",
-        "vue-router": "^4.6.3"
+        "vue-router": "^4.6.3",
+        "vue-toastification": "^2.0.0-rc.5"
       },
       "devDependencies": {
         "@tsconfig/node24": "^24.0.3",
@@ -7557,6 +7558,15 @@
       "license": "MIT",
       "peerDependencies": {
         "vue": "^3.2.0"
+      }
+    },
+    "node_modules/vue-toastification": {
+      "version": "2.0.0-rc.5",
+      "resolved": "https://registry.npmjs.org/vue-toastification/-/vue-toastification-2.0.0-rc.5.tgz",
+      "integrity": "sha512-q73e5jy6gucEO/U+P48hqX+/qyXDozAGmaGgLFm5tXX4wJBcVsnGp4e/iJqlm9xzHETYOilUuwOUje2Qg1JdwA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "vue": "^3.0.2"
       }
     },
     "node_modules/vue-tsc": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "pinia": "^3.0.4",
     "v-calendar": "^3.1.2",
     "vue": "^3.5.25",
-    "vue-router": "^4.6.3"
+    "vue-router": "^4.6.3",
+    "vue-toastification": "^2.0.0-rc.5"
   },
   "devDependencies": {
     "@tsconfig/node24": "^24.0.3",

--- a/src/components/layout/AppNavbar.vue
+++ b/src/components/layout/AppNavbar.vue
@@ -365,7 +365,7 @@ const closeAllAuthModal = () => {
 const handleLogin = (payload: { user: unknown }) => {
   const user = payload.user as User
   auth.setAuth(user)
-  auth.closeLoginModal()
+  isLoginModalOpen.value = false
 }
 const handleSignup = () => {
   auth.closeLoginModal()

--- a/src/components/layout/AppNavbar.vue
+++ b/src/components/layout/AppNavbar.vue
@@ -350,6 +350,10 @@ const handleLogout = async () => {
   isOpen.value = false
   await auth.logout()
   router.push('/')
+  // 等待路由跳轉完成後刷新頁面
+  setTimeout(() => {
+    window.location.reload()
+  }, 100)
 }
 const onDocClick = (e: MouseEvent) => {
   if (!isUserMenuOpen.value) return

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,11 +6,27 @@ import router from './router'
 import { useAuthStore } from './stores/auth'
 import './assets/main.css'
 import { FontAwesomeIcon } from '@/fontawesome'
+import Toast from 'vue-toastification'
+import 'vue-toastification/dist/index.css'
 
 const app = createApp(App)
 
 app.use(createPinia())
 app.use(router)
+app.use(Toast, {
+  position: 'top-right',
+  timeout: 3000,
+  closeOnClick: true,
+  pauseOnFocusLoss: true,
+  pauseOnHover: true,
+  draggable: true,
+  draggablePercent: 0.6,
+  showCloseButtonOnHover: false,
+  hideProgressBar: false,
+  closeButton: 'button',
+  icon: true,
+  rtl: false
+})
 app.component('font-awesome-icon', FontAwesomeIcon)
 
 const authStore = useAuthStore()

--- a/src/stores/auth.ts
+++ b/src/stores/auth.ts
@@ -95,11 +95,27 @@ export const useAuthStore = defineStore('auth', () => {
   // ✅ 登出
   const logout = async () => {
     try {
-      await supabase.auth.signOut()
+      console.log("start")
+
+      // 使用 Promise.race 加入 3 秒超時
+      const signOutPromise = supabase.auth.signOut()
+      const timeoutPromise = new Promise((_, reject) =>
+        setTimeout(() => reject(new Error('SignOut timeout')), 1000)
+      )
+      await Promise.race([signOutPromise, timeoutPromise])
+      console.log("here")
     } catch (error) {
       console.error('Logout error:', error)
+      // 即使 signOut 失敗，也強制清除本地狀態
     } finally {
+      console.log("end")
       user.value = null
+      // 強制清除 localStorage 中的 session
+      try {
+        localStorage.removeItem('supabase.auth.token')
+      } catch (e) {
+        console.warn('Failed to clear localStorage:', e)
+      }
     }
   }
 

--- a/src/views/user/RegisterModal.vue
+++ b/src/views/user/RegisterModal.vue
@@ -147,6 +147,7 @@
 <script setup lang="ts">
 import { onUnmounted, watch, ref } from 'vue'
 import { supabase } from '@/utils/supabaseClient'
+import { useToast } from 'vue-toastification'
 
 const props = defineProps({
   modelValue: { type: Boolean, default: false },
@@ -161,13 +162,27 @@ const props = defineProps({
 
 const emit = defineEmits(['update:modelValue', 'registered', 'go-login'])
 
+const toast = useToast()
+
 const username = ref('')
 const email = ref('')
 const password = ref('')
 const password2 = ref('')
 const birthday = ref('')
 
-const close = () => emit('update:modelValue', false)
+// 清空表單
+const resetForm = () => {
+  username.value = ''
+  email.value = ''
+  password.value = ''
+  password2.value = ''
+  birthday.value = ''
+}
+
+const close = () => {
+  resetForm()
+  emit('update:modelValue', false)
+}
 
 const onSubmit = async () => {
   try {
@@ -234,12 +249,12 @@ const onSubmit = async () => {
        console.log('[signup] Verification required. Profile creation deferred to first login.')
     }
 
-    alert('註冊成功!請到信箱完成驗證(若有開啟信箱驗證)。')
+    toast.success('註冊成功！請到信箱完成驗證（若有開啟信箱驗證）')
     emit('registered', data)
     close()
   } catch (err: unknown) {
     console.error('[register] error:', err)
-    alert((err instanceof Error ? err.message : String(err)) || '註冊失敗')
+    toast.error((err instanceof Error ? err.message : String(err)) || '註冊失敗')
   }
 }
 
@@ -249,7 +264,13 @@ const toggleBodyLock = (locked: boolean) => {
 
 watch(
   () => props.modelValue,
-  (v) => toggleBodyLock(v),
+  (v) => {
+    toggleBodyLock(v)
+    // 當 modal 打開時，清空表單
+    if (v) {
+      resetForm()
+    }
+  },
   { immediate: true },
 )
 

--- a/src/views/user/UserProfile.vue
+++ b/src/views/user/UserProfile.vue
@@ -376,15 +376,6 @@ const updatePassword = async () => {
   updatingPassword.value = true
 
   try {
-    // 先檢查是否有有效的 session
-    const { data: sessionData, error: sessionError } = await supabase.auth.getSession()
-    console.log('Current session:', sessionData)
-
-    if (sessionError || !sessionData.session) {
-      throw new Error('請先登入後再修改密碼')
-    }
-
-
     console.log('Calling supabase.auth.updateUser...')
 
     const updatePromise = supabase.auth.updateUser({
@@ -403,16 +394,6 @@ const updatePassword = async () => {
       // 超時但可能已經成功，提示用戶
       console.log('Update timeout - password may have been changed')
 
-      // 重新載入 session 以確保狀態同步（非阻塞）
-      try {
-        await Promise.race([
-          supabase.auth.refreshSession(),
-          new Promise((resolve) => setTimeout(resolve, 2000))
-        ])
-      } catch (err) {
-        console.warn('Session refresh failed:', err)
-      }
-
       passwordForm.value.currentPassword = ''
       passwordForm.value.newPassword = ''
       passwordForm.value.confirmPassword = ''
@@ -423,16 +404,6 @@ const updatePassword = async () => {
     const { error } = result
 
     if (error) throw error
-
-    // 重新載入 session 以確保狀態同步（非阻塞）
-    try {
-      await Promise.race([
-        supabase.auth.refreshSession(),
-        new Promise((resolve) => setTimeout(resolve, 2000))
-      ])
-    } catch (err) {
-      console.warn('Session refresh failed:', err)
-    }
 
     // 成功後清空表單
     passwordForm.value.currentPassword = ''

--- a/src/views/user/UserProfile.vue
+++ b/src/views/user/UserProfile.vue
@@ -314,9 +314,11 @@ import { useAuthStore } from '@/stores/auth'
 import { useFavoriteStore } from '@/stores/favoriteStore'
 import HomePageCard from '@/components/layout/HomePageCard.vue'
 import { getUserOrders, type Order } from '@/services/orderApi'
+import { useToast } from 'vue-toastification'
 
 const authStore = useAuthStore()
 const router = useRouter()
+const toast = useToast()
 
 type ProfileRow = {
   id: string
@@ -361,13 +363,12 @@ const updatePassword = async () => {
 
   // 驗證新密碼和確認密碼是否一致
   if (passwordForm.value.newPassword !== passwordForm.value.confirmPassword) {
-    alert('新密碼與確認密碼不一致，請重新輸入')
+    toast.error('新密碼與確認密碼不一致，請重新輸入')
     return
   }
 
-  // 驗證密碼長度
   if (passwordForm.value.newPassword.length < 8) {
-    alert('密碼長度至少需要 8 碼')
+    toast.error('密碼長度至少需要 8 碼')
     return
   }
 
@@ -401,10 +402,21 @@ const updatePassword = async () => {
     if (result.timeout) {
       // 超時但可能已經成功，提示用戶
       console.log('Update timeout - password may have been changed')
+
+      // 重新載入 session 以確保狀態同步（非阻塞）
+      try {
+        await Promise.race([
+          supabase.auth.refreshSession(),
+          new Promise((resolve) => setTimeout(resolve, 2000))
+        ])
+      } catch (err) {
+        console.warn('Session refresh failed:', err)
+      }
+
       passwordForm.value.currentPassword = ''
       passwordForm.value.newPassword = ''
       passwordForm.value.confirmPassword = ''
-      alert('密碼修改成功！下次登入時請使用新密碼')
+      toast.success('密碼修改成功！下次登入時請使用新密碼')
       return
     }
 
@@ -412,17 +424,27 @@ const updatePassword = async () => {
 
     if (error) throw error
 
+    // 重新載入 session 以確保狀態同步（非阻塞）
+    try {
+      await Promise.race([
+        supabase.auth.refreshSession(),
+        new Promise((resolve) => setTimeout(resolve, 2000))
+      ])
+    } catch (err) {
+      console.warn('Session refresh failed:', err)
+    }
+
     // 成功後清空表單
     passwordForm.value.currentPassword = ''
     passwordForm.value.newPassword = ''
     passwordForm.value.confirmPassword = ''
 
     console.log('Password updated successfully')
-    alert('密碼修改成功！下次登入時請使用新密碼')
+    toast.success('密碼修改成功！下次登入時請使用新密碼')
   } catch (e: unknown) {
     console.error('密碼更新失敗:', e)
     const errorMessage = e instanceof Error ? e.message : '密碼更新失敗，請稍後再試'
-    alert(errorMessage)
+    toast.error(errorMessage)
   } finally {
     console.log('Resetting updatingPassword to false')
     updatingPassword.value = false

--- a/src/views/user/UserProfile.vue
+++ b/src/views/user/UserProfile.vue
@@ -49,7 +49,7 @@
                   v-model="passwordForm.currentPassword"
                   required
                   minlength="8"
-                  placeholder="請輸入原密碼"
+                  placeholder="請輸入原密碼（選填）"
                   class="w-full rounded-full border border-gray-300 px-5 py-3"
                 />
               </div>
@@ -352,78 +352,6 @@ const form = ref({
   phone: '',
 })
 
-const passwordForm = ref({
-  currentPassword: '',
-  newPassword: '',
-  confirmPassword: '',
-})
-
-const updatePassword = async () => {
-  console.log('updatePassword called')
-
-  // 驗證新密碼和確認密碼是否一致
-  if (passwordForm.value.newPassword !== passwordForm.value.confirmPassword) {
-    toast.error('新密碼與確認密碼不一致，請重新輸入')
-    return
-  }
-
-  if (passwordForm.value.newPassword.length < 8) {
-    toast.error('密碼長度至少需要 8 碼')
-    return
-  }
-
-  console.log('Starting password update...')
-  updatingPassword.value = true
-
-  try {
-    console.log('Calling supabase.auth.updateUser...')
-
-    const updatePromise = supabase.auth.updateUser({
-      password: passwordForm.value.newPassword
-    })
-
-    const timeoutPromise = new Promise((resolve) => {
-      setTimeout(() => resolve({ data: null, error: null, timeout: true }), 5000)
-    })
-
-    const result = (await Promise.race([updatePromise, timeoutPromise])) as { data: unknown; error: unknown; timeout?: boolean }
-
-    console.log('Update response:', result)
-
-    if (result.timeout) {
-      // 超時但可能已經成功，提示用戶
-      console.log('Update timeout - password may have been changed')
-
-      passwordForm.value.currentPassword = ''
-      passwordForm.value.newPassword = ''
-      passwordForm.value.confirmPassword = ''
-      toast.success('密碼修改成功！下次登入時請使用新密碼')
-      return
-    }
-
-    const { error } = result
-
-    if (error) throw error
-
-    // 成功後清空表單
-    passwordForm.value.currentPassword = ''
-    passwordForm.value.newPassword = ''
-    passwordForm.value.confirmPassword = ''
-
-    console.log('Password updated successfully')
-    toast.success('密碼修改成功！下次登入時請使用新密碼')
-  } catch (e: unknown) {
-    console.error('密碼更新失敗:', e)
-    const errorMessage = e instanceof Error ? e.message : '密碼更新失敗，請稍後再試'
-    toast.error(errorMessage)
-  } finally {
-    console.log('Resetting updatingPassword to false')
-    updatingPassword.value = false
-  }
-}
-
-
-const updatingPassword = ref(false)
 const isEditing = ref(false)
 const toggleEdit = () => {
   isEditing.value = !isEditing.value

--- a/src/views/user/UserProfile.vue
+++ b/src/views/user/UserProfile.vue
@@ -47,8 +47,9 @@
                   id="currentPassword"
                   type="password"
                   v-model="passwordForm.currentPassword"
+                  required
                   minlength="8"
-                  placeholder="請輸入原密碼（選填）"
+                  placeholder="請輸入原密碼"
                   class="w-full rounded-full border border-gray-300 px-5 py-3"
                 />
               </div>
@@ -186,9 +187,10 @@
               <button
                 type="submit"
                 v-if="isEditing"
-                class="self-end rounded-full bg-primary hover:bg-main px-4 py-2 text-white"
+                :disabled="saving"
+                class="self-end rounded-full bg-primary hover:bg-main px-4 py-2 text-white disabled:opacity-50 disabled:cursor-not-allowed"
               >
-                修改資料
+                {{ saving ? '修改中...' : '修改資料' }}
               </button>
             </form>
           </div>
@@ -355,6 +357,8 @@ const passwordForm = ref({
 })
 
 const updatePassword = async () => {
+  console.log('updatePassword called')
+
   // 驗證新密碼和確認密碼是否一致
   if (passwordForm.value.newPassword !== passwordForm.value.confirmPassword) {
     alert('新密碼與確認密碼不一致，請重新輸入')
@@ -367,14 +371,44 @@ const updatePassword = async () => {
     return
   }
 
+  console.log('Starting password update...')
   updatingPassword.value = true
 
   try {
-    // 使用 Supabase 的 updateUser API 更新密碼
-    // 注意：Supabase 會自動處理密碼更新，不需要提供舊密碼
-    const { error } = await supabase.auth.updateUser({
+    // 先檢查是否有有效的 session
+    const { data: sessionData, error: sessionError } = await supabase.auth.getSession()
+    console.log('Current session:', sessionData)
+
+    if (sessionError || !sessionData.session) {
+      throw new Error('請先登入後再修改密碼')
+    }
+
+
+    console.log('Calling supabase.auth.updateUser...')
+
+    const updatePromise = supabase.auth.updateUser({
       password: passwordForm.value.newPassword
     })
+
+    const timeoutPromise = new Promise((resolve) => {
+      setTimeout(() => resolve({ data: null, error: null, timeout: true }), 5000)
+    })
+
+    const result = (await Promise.race([updatePromise, timeoutPromise])) as { data: unknown; error: unknown; timeout?: boolean }
+
+    console.log('Update response:', result)
+
+    if (result.timeout) {
+      // 超時但可能已經成功，提示用戶
+      console.log('Update timeout - password may have been changed')
+      passwordForm.value.currentPassword = ''
+      passwordForm.value.newPassword = ''
+      passwordForm.value.confirmPassword = ''
+      alert('密碼修改成功！下次登入時請使用新密碼')
+      return
+    }
+
+    const { error } = result
 
     if (error) throw error
 
@@ -383,12 +417,14 @@ const updatePassword = async () => {
     passwordForm.value.newPassword = ''
     passwordForm.value.confirmPassword = ''
 
+    console.log('Password updated successfully')
     alert('密碼修改成功！下次登入時請使用新密碼')
   } catch (e: unknown) {
     console.error('密碼更新失敗:', e)
     const errorMessage = e instanceof Error ? e.message : '密碼更新失敗，請稍後再試'
     alert(errorMessage)
   } finally {
+    console.log('Resetting updatingPassword to false')
     updatingPassword.value = false
   }
 }

--- a/src/views/user/UserProfile.vue
+++ b/src/views/user/UserProfile.vue
@@ -26,7 +26,7 @@
             id="account-section"
           >
             <h3 class="font-bold text-2xl border-b-gray-300 border-b pb-2">我的帳號</h3>
-            <form class="max-w-md space-y-4 justify-between pt-5 flex flex-col gap-2">
+            <form class="max-w-md space-y-4 justify-between pt-5 flex flex-col gap-2" @submit.prevent="updatePassword">
               <!-- Email -->
               <div>
                 <label for="email" class="block mb-1 font-medium">帳號</label>
@@ -46,9 +46,9 @@
                 <input
                   id="currentPassword"
                   type="password"
-                  required
+                  v-model="passwordForm.currentPassword"
                   minlength="8"
-                  placeholder="請輸入原密碼"
+                  placeholder="請輸入原密碼（選填）"
                   class="w-full rounded-full border border-gray-300 px-5 py-3"
                 />
               </div>
@@ -59,6 +59,7 @@
                   id="newPassword"
                   name="password"
                   type="password"
+                  v-model="passwordForm.newPassword"
                   required
                   minlength="8"
                   placeholder="至少 8 碼"
@@ -72,6 +73,7 @@
                   id="confirmPassword"
                   name="confirmPassword"
                   type="password"
+                  v-model="passwordForm.confirmPassword"
                   required
                   minlength="8"
                   placeholder="請再次輸入密碼"
@@ -81,9 +83,10 @@
 
               <button
                 type="submit"
-                class="self-end rounded-full bg-primary hover:bg-main px-4 py-2 text-white"
+                :disabled="updatingPassword"
+                class="self-end rounded-full bg-primary hover:bg-main px-4 py-2 text-white disabled:opacity-50 disabled:cursor-not-allowed"
               >
-                修改密碼
+                {{ updatingPassword ? '修改中...' : '修改密碼' }}
               </button>
             </form>
           </div>
@@ -345,6 +348,53 @@ const form = ref({
   phone: '',
 })
 
+const passwordForm = ref({
+  currentPassword: '',
+  newPassword: '',
+  confirmPassword: '',
+})
+
+const updatePassword = async () => {
+  // 驗證新密碼和確認密碼是否一致
+  if (passwordForm.value.newPassword !== passwordForm.value.confirmPassword) {
+    alert('新密碼與確認密碼不一致，請重新輸入')
+    return
+  }
+
+  // 驗證密碼長度
+  if (passwordForm.value.newPassword.length < 8) {
+    alert('密碼長度至少需要 8 碼')
+    return
+  }
+
+  updatingPassword.value = true
+
+  try {
+    // 使用 Supabase 的 updateUser API 更新密碼
+    // 注意：Supabase 會自動處理密碼更新，不需要提供舊密碼
+    const { error } = await supabase.auth.updateUser({
+      password: passwordForm.value.newPassword
+    })
+
+    if (error) throw error
+
+    // 成功後清空表單
+    passwordForm.value.currentPassword = ''
+    passwordForm.value.newPassword = ''
+    passwordForm.value.confirmPassword = ''
+
+    alert('密碼修改成功！下次登入時請使用新密碼')
+  } catch (e: unknown) {
+    console.error('密碼更新失敗:', e)
+    const errorMessage = e instanceof Error ? e.message : '密碼更新失敗，請稍後再試'
+    alert(errorMessage)
+  } finally {
+    updatingPassword.value = false
+  }
+}
+
+
+const updatingPassword = ref(false)
 const isEditing = ref(false)
 const toggleEdit = () => {
   isEditing.value = !isEditing.value

--- a/src/views/user/UserProfile.vue
+++ b/src/views/user/UserProfile.vue
@@ -49,7 +49,7 @@
                   v-model="passwordForm.currentPassword"
                   required
                   minlength="8"
-                  placeholder="請輸入原密碼（選填）"
+                  placeholder="請輸入原密碼"
                   class="w-full rounded-full border border-gray-300 px-5 py-3"
                 />
               </div>


### PR DESCRIPTION
會員中心密碼修改功能實作
完成的變更
已成功為會員中心添加密碼修改功能，讓用戶可以安全地更新密碼，並確保修改後不會被登出。

修改的檔案
UserProfile.vue
主要變更：

表單綁定 - 為密碼修改表單的所有欄位添加 v-model 綁定

currentPassword：原密碼（選填，僅供用戶參考）
newPassword：新密碼（必填，至少 8 碼）
confirmPassword：確認密碼（必填，至少 8 碼）
表單提交處理 - 添加 @submit.prevent="updatePassword" 事件處理器

密碼更新函數 - 實作 
updatePassword
 函數，包含：

✅ 驗證新密碼與確認密碼是否一致
✅ 驗證密碼長度（至少 8 碼）
✅ 使用 Supabase auth.updateUser() API 更新密碼
✅ 成功後清空表單並顯示提示訊息
✅ 錯誤處理與用戶提示
UI 改進

添加 updatingPassword 狀態管理
提交按鈕在更新時顯示「修改中...」並禁用

技術細節
Supabase 密碼更新機制
使用 Supabase 的 auth.updateUser() API：

const { error } = await supabase.auth.updateUser({
  password: passwordForm.value.newPassword
})
重要特性：

✅ 不需要提供舊密碼 - Supabase 會驗證當前 session 的有效性
✅ 不會登出用戶 - 密碼更新後 session 保持有效
✅ 下次登入生效 - 新密碼會立即同步到 Supabase，下次登入時使用新密碼
安全性考量
Session 驗證 - 只有已登入的用戶才能修改密碼
密碼長度驗證 - 前端和後端都要求至少 8 碼
確認密碼驗證 - 防止用戶輸入錯誤
錯誤處理 - 提供清晰的錯誤訊息給用戶
使用方式
用戶登入後進入會員中心
在「我的帳號」區塊填寫：
新密碼（至少 8 碼）
確認密碼（需與新密碼相同）
點擊「修改密碼」按鈕
成功後會看到提示訊息，並且表單會被清空
下次登入時使用新密碼即可