### PR TITLE
fix: 體驗頁面日期選取與免費商品的顯示

### DIFF
--- a/src/components/layout/HomePageTicketCard.vue
+++ b/src/components/layout/HomePageTicketCard.vue
@@ -1,18 +1,23 @@
 <template>
-  <RouterLink :to="`/tickets/${id}`" :class="[
-    'group relative flex h-[270px] w-[183px] hover:w-[408px] z-[1] hover:z-[20] bg-white rounded-[20px] hover:rounded-[30px] overflow-hidden border border-gray-300 transition-all duration-500 ease-in-out cursor-pointer shadow-sm hover:shadow-xl flex-shrink-0',
-    expandLeft ? 'hover:-translate-x-[225px]' : ''
-  ]">
+  <RouterLink
+    :to="`/tickets/${id}`"
+    :class="[
+      'group relative flex h-[270px] w-[183px] hover:w-[408px] z-[1] hover:z-[20] bg-white rounded-[20px] hover:rounded-[30px] overflow-hidden border border-gray-300 transition-all duration-500 ease-in-out cursor-pointer shadow-sm hover:shadow-xl flex-shrink-0',
+      expandLeft ? 'hover:-translate-x-[225px]' : '',
+    ]"
+  >
     <div class="relative h-full w-[183px] flex-shrink-0">
-      <img :src="imageUrl" :alt="name" class="h-full w-full object-cover" />
+      <img :src="image_url" :alt="name" class="h-full w-full object-cover" />
       <div
-        class="absolute bottom-0 left-0 w-full p-4 bg-gradient-to-t from-black/60 to-transparent group-hover:opacity-0 transition-opacity duration-300">
+        class="absolute bottom-0 left-0 w-full p-4 bg-gradient-to-t from-black/60 to-transparent group-hover:opacity-0 transition-opacity duration-300"
+      >
         <h3 class="text-white font-bold text-base line-clamp-1 lg:text-lg">{{ name }}</h3>
         <p class="text-white/90 text-sm">NT$ {{ (price || 0).toLocaleString() }} /起</p>
       </div>
     </div>
     <div
-      class="flex flex-col flex-1 p-5 opacity-0 group-hover:opacity-100 transition-opacity duration-500 delay-150 w-full">
+      class="flex flex-col flex-1 p-5 opacity-0 group-hover:opacity-100 transition-opacity duration-500 delay-150 w-full"
+    >
       <div class="flex-1">
         <h3 class="text-lg lg:text-xl font-bold text-black">{{ name }}</h3>
         <div class="flex text-dark_300">
@@ -21,26 +26,40 @@
         <p class="text-dark_500 text-sm leading-relaxed">
           {{ category }}
         </p>
-        <p class="text-dark_500 text-sm leading-relaxed">
-          {{ venue || address }}{{ address }}
-        </p>
+        <p class="text-dark_500 text-sm leading-relaxed">{{ city || address }}{{ address }}</p>
       </div>
       <div class="mt-auto text-nowrap">
         <div class="text-right mb-1 text-xs text-dark_500">
-          <span class="text-red-500 font-bold text-lg">NT$ {{ (price || 0).toLocaleString() }}</span> /起
+          <span class="text-red-500 font-bold text-lg"
+            >NT$ {{ (price || 0).toLocaleString() }}</span
+          >
+          /起
         </div>
         <div class="flex justify-end gap-3">
-          <button @click.stop.prevent="onFavoriteClick"
-            class="p-2 rounded-full border border-gray-300 hover:bg-main_100 transition-colors">
-            <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 transition-colors"
-              :class="isFav ? 'text-red-500 fill-red-500' : 'text-dark_500'" :fill="isFav ? 'currentColor' : 'none'"
-              viewBox="0 0 24 24" stroke="currentColor">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z" />
+          <button
+            @click.stop.prevent="onFavoriteClick"
+            class="p-2 rounded-full border border-gray-300 hover:bg-main_100 transition-colors"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              class="h-6 w-6 transition-colors"
+              :class="isFav ? 'text-red-500 fill-red-500' : 'text-dark_500'"
+              :fill="isFav ? 'currentColor' : 'none'"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z"
+              />
             </svg>
           </button>
-          <button @click.stop="$emit('details', id)"
-            class="h-10 bg-primary hover:bg-main text-white px-6 rounded-full font-medium transition-colors">
+          <button
+            @click.stop="$emit('details', id)"
+            class="h-10 bg-primary hover:bg-main text-white px-6 rounded-full font-medium transition-colors"
+          >
             了解更多
           </button>
         </div>
@@ -50,37 +69,37 @@
 </template>
 
 <script setup lang="ts">
-import { RouterLink } from 'vue-router';
-import { useFavoriteStore } from '@/stores/favoriteStore';
+import { RouterLink } from 'vue-router'
+import { useFavoriteStore } from '@/stores/favoriteStore'
 import { useAuthStore } from '@/stores/auth'
-import { computed } from 'vue';
+import { computed } from 'vue'
 
 // 統一命名規範與預設值
 interface Props {
-  id?: number | string;
-  name?: string;
-  imageUrl?: string;
-  price?: number;
-  venue?: string;
-  category?: string;
-  date?: string;
-  address?: string;
-  rating?: number;
-  expandLeft?: boolean;
+  id?: number | string
+  name?: string
+  image_url?: string
+  price?: number
+  city?: string
+  category?: string
+  date?: string
+  address?: string
+  rating?: number
+  expandLeft?: boolean
 }
 
 const props = withDefaults(defineProps<Props>(), {
   id: 0,
   name: '卡片名稱',
-  imageUrl: 'https://images.unsplash.com/photo-1566073771259-6a8506099945?w=400',
+  image_url: 'https://images.unsplash.com/photo-1566073771259-6a8506099945?w=400',
   price: 0,
-  venue: '',
+  city: '',
   category: '',
   date: 'YYYY-MM-DD',
   address: '',
   rating: 5,
-  expandLeft: false
-});
+  expandLeft: false,
+})
 
 const favoriteStore = useFavoriteStore()
 const authStore = useAuthStore()
@@ -91,30 +110,30 @@ const isFav = computed(() => {
 
 const onFavoriteClick = async () => {
   if (!authStore.isLoggedIn) {
-     alert('請先登入會員以加入收藏')
-     return
+    alert('請先登入會員以加入收藏')
+    return
   }
   if (!props.id) {
-    console.warn('Cannot add item with invalid ID to favorites.');
-    return;
+    console.warn('Cannot add item with invalid ID to favorites.')
+    return
   }
   try {
     await favoriteStore.toggleFavorite({
-        id: props.id!,
-        name: props.name!,
-        imageUrl: props.imageUrl!,
-        price: props.price!,
-        venue: props.venue,
-        category: props.category,
-        date: props.date,
-        address: props.address,
-        rating: props.rating,
-        type: 'ticket'
+      id: props.id!,
+      name: props.name!,
+      imageUrl: props.image_url!,
+      price: props.price!,
+      city: props.city,
+      category: props.category,
+      date: props.date,
+      address: props.address,
+      rating: props.rating,
+      type: 'ticket',
     })
   } catch {
     // Error handled in store
   }
 }
 
-defineEmits(['compare', 'favorite', 'details']);
+defineEmits(['compare', 'favorite', 'details'])
 </script>

--- a/src/views/HomePage.vue
+++ b/src/views/HomePage.vue
@@ -7,7 +7,7 @@
         <div class="relative">
           <div class="relative w-full overflow-hidden rounded-[40px] bg-gray-200 shadow-sm">
             <img
-              src="https://res.cloudinary.com/wantrip/image/upload/v1767445158/%E5%9F%8E%E5%B8%82_luoarw.jpg"
+              src="https://res.cloudinary.com/wantrip/image/upload/v1768481888/IMG_7318_dizpjn.jpg"
               class="aspect-[3/4] absolute inset-0 w-full h-full object-fill"
               alt="banner"
             />
@@ -16,46 +16,46 @@
 
           <!-- Search Bar (floating on banner) -->
           <div class="absolute inset-x-0 bottom-0 z-20 flex justify-center translate-y-1/2">
-             <div class="w-full lg:max-w-[1024px]">
-                 <!-- Tabs -->
-                  <div
-                    class="relative w-fit h-11 flex items-center rounded-full border border-gray-300 bg-white p-0.5 mb-2 mx-auto md:mx-0 overflow-hidden"
-                  >
-                    <!-- Sliding Background Indicator -->
-                    <div
-                      class="absolute top-0.5 bottom-0.5 left-0.5 w-[96px] rounded-full bg-primary shadow-sm transition-all duration-300 ease-in-out z-0"
-                      :style="{ transform: `translateX(${activeTab === 'stay' ? '96px' : '0px'})` }"
-                    ></div>
+            <div class="w-full lg:max-w-[1024px]">
+              <!-- Tabs -->
+              <div
+                class="relative w-fit h-11 flex items-center rounded-full border border-gray-300 bg-white p-0.5 mb-2 mx-auto md:mx-0 overflow-hidden"
+              >
+                <!-- Sliding Background Indicator -->
+                <div
+                  class="absolute top-0.5 bottom-0.5 left-0.5 w-[96px] rounded-full bg-primary shadow-sm transition-all duration-300 ease-in-out z-0"
+                  :style="{ transform: `translateX(${activeTab === 'stay' ? '96px' : '0px'})` }"
+                ></div>
 
-                    <button
-                      type="button"
-                      class="relative z-10 h-full rounded-full text-nowrap w-24 text-sm font-semibold transition-colors duration-300 px-4"
-                      :class="activeTab === 'package' ? 'text-white' : 'text-dark hover:bg-main_100/50'"
-                      @click="activeTab = 'package'"
-                    >
-                      找門票
-                    </button>
-                    <button
-                      type="button"
-                      class="relative z-10 h-full rounded-full text-nowrap w-24 text-sm font-semibold transition-colors duration-300 px-4"
-                      :class="activeTab === 'stay' ? 'text-white' : 'text-dark hover:bg-main_100/50'"
-                      @click="activeTab = 'stay'"
-                    >
-                      找住宿
-                    </button>
-                  </div>
+                <button
+                  type="button"
+                  class="relative z-10 h-full rounded-full text-nowrap w-24 text-sm font-semibold transition-colors duration-300 px-4"
+                  :class="activeTab === 'package' ? 'text-white' : 'text-dark hover:bg-main_100/50'"
+                  @click="activeTab = 'package'"
+                >
+                  找門票
+                </button>
+                <button
+                  type="button"
+                  class="relative z-10 h-full rounded-full text-nowrap w-24 text-sm font-semibold transition-colors duration-300 px-4"
+                  :class="activeTab === 'stay' ? 'text-white' : 'text-dark hover:bg-main_100/50'"
+                  @click="activeTab = 'stay'"
+                >
+                  找住宿
+                </button>
+              </div>
 
-                <SearchBar
-                    mode="redirect"
-                    :search-type="activeTab"
-                    :initial-keyword="hotelConfig.destination"
-                    :initial-range="hotelConfig.dateRange"
-                    :initial-people="hotelConfig.guests"
-                    :initial-destination="ticketConfig.destination"
-                    :initial-ticket-guests="ticketConfig.guests"
-                    @search="handleSearch"
-                />
-             </div>
+              <SearchBar
+                mode="redirect"
+                :search-type="activeTab"
+                :initial-keyword="hotelConfig.destination"
+                :initial-range="hotelConfig.dateRange"
+                :initial-people="hotelConfig.guests"
+                :initial-destination="ticketConfig.destination"
+                :initial-ticket-guests="ticketConfig.guests"
+                @search="handleSearch"
+              />
+            </div>
           </div>
         </div>
       </section>
@@ -219,10 +219,12 @@ onMounted(async () => {
     // Map API data to match TicketCard props if necessary, or ensure TicketCard accepts API structure.
     // TicketHomeView passes the API data directly to HomePageTicketCard.
     // Let's assume HomePageTicketCard handles it (it takes :v-bind="ticket").
-    recommendations.value = res.data.map((item: Omit<TicketItem, 'rating'> & { rating: string | number }) => ({
+    recommendations.value = res.data.map(
+      (item: Omit<TicketItem, 'rating'> & { rating: string | number }) => ({
         ...item,
-        rating: Number(item.rating)
-    }))
+        rating: Number(item.rating),
+      }),
+    )
   } catch (error) {
     console.error('Error fetching popular tickets:', error)
   }
@@ -264,15 +266,15 @@ interface SearchPayload {
 function handleSearch(payload: SearchPayload) {
   // Search logic is handled by SearchBar's redirect mode
   if (activeTab.value === 'package') {
-     ticketConfig.destination = payload.destination || ''
-     if (payload.guests) {
-        Object.assign(ticketConfig.guests, payload.guests)
-     }
+    ticketConfig.destination = payload.destination || ''
+    if (payload.guests) {
+      Object.assign(ticketConfig.guests, payload.guests)
+    }
   } else {
-     hotelConfig.destination = payload.keyword || ''
-     if(payload.range) hotelConfig.dateRange = payload.range
-     hotelConfig.guests.rooms = payload.rooms || 1
-     hotelConfig.guests.people = payload.people || 2
+    hotelConfig.destination = payload.keyword || ''
+    if (payload.range) hotelConfig.dateRange = payload.range
+    hotelConfig.guests.rooms = payload.rooms || 1
+    hotelConfig.guests.people = payload.people || 2
   }
 }
 

--- a/src/views/HomePage.vue
+++ b/src/views/HomePage.vue
@@ -232,7 +232,6 @@ onMounted(async () => {
 
 const handleWishlist = (id: string | number) => {
   const product = hotHotelsA.value.find((t) => t.id === id)
-  console.log(`用戶收藏了: ${product?.name}`)
 }
 
 const handleBook = (id: string | number) => {
@@ -246,7 +245,6 @@ const selectedKeywords = reactive(new Set<string>())
 function toggleKeyword(k: string) {
   if (selectedKeywords.has(k)) selectedKeywords.delete(k)
   else selectedKeywords.add(k)
-  console.log('[Stay Keyword Toggle]', Array.from(selectedKeywords))
 }
 
 // Methods
@@ -291,7 +289,6 @@ function onClickRegion(region: { key: string }) {
     })
   } else {
     // Fallback or default behavior
-    console.log('Unknown region:', region.key)
   }
 }
 

--- a/src/views/hotel/HotelHomeView.vue
+++ b/src/views/hotel/HotelHomeView.vue
@@ -79,7 +79,6 @@
 
 <script setup lang="ts">
 import { reactive, ref, watch, onMounted, onUnmounted, computed } from 'vue'
-import 'v-calendar/style.css'
 import { useRouter } from 'vue-router'
 import HomePageCard from '@/components/layout/HomePageCard.vue'
 import { useHotelApi } from '@/composables/useHotelApi'

--- a/src/views/hotel/HotelMapSearch.vue
+++ b/src/views/hotel/HotelMapSearch.vue
@@ -42,147 +42,147 @@
             v-show="isMobileSearchOpen"
             class="flex flex-col md:flex-row md:flex-grow gap-2 md:items-center md:!flex p-4 md:p-0 bg-white/80 md:bg-transparent backdrop-blur-md md:backdrop-blur-0 rounded-[24px] md:rounded-none shadow-lg md:shadow-none border border-white/20 md:border-none"
           >
-              <label
-                class="md:flex-1 relative rounded-[20px] bg-white px-5 h-[60px] flex flex-col justify-center gap-1 shadow-sm ring-1 ring-primary/10 group cursor-pointer transition-all hover:ring-primary/50"
-              >
-                <p class="text-xs font-bold leading-tight text-primary/70">目的地</p>
-                <div class="relative">
-                  <input
-                    v-model="keyword"
-                    class="w-full bg-transparent outline-none appearance-none cursor-pointer pr-8 text-base text-black truncate transition-colors"
-                    type="text"
-                    placeholder="想住哪～"
-                  />
-                </div>
-              </label>
-
-              <div class="relative flex h-[60px] md:flex-[1.2]">
-                <VueDatePicker
-                  v-model="range"
-                  range
-                  :min-range="1"
-                  :enable-time-picker="false"
-                  format="yyyy-MM-dd"
-                  :min-date="new Date()"
-                  auto-apply
-                  hide-input-icon
-                  :clearable="false"
-                  class="w-full h-full"
-                  @update:model-value="handleDateChange"
-                  @open="activePicker = 'date'"
-                  @closed="activePicker = 'none'"
-                >
-                  <template #dp-input>
-                    <div
-                      class="w-full h-full rounded-[20px] bg-white px-5 flex flex-col justify-center gap-1 shadow-sm ring-1 ring-primary/10 transition-all hover:ring-accent/50 cursor-pointer"
-                      :class="{ 'ring-accent/50': activePicker === 'date' }"
-                    >
-                      <p class="text-xs font-bold leading-tight text-primary/70">入住 - 退房日期</p>
-                      <input
-                        :value="formatRangeDisplay()"
-                        class="w-full bg-transparent text-sm md:text-base text-black outline-none pointer-events-none"
-                        placeholder="點選選擇日期"
-                        readonly
-                      />
-                    </div>
-                  </template>
-                </VueDatePicker>
+            <label
+              class="md:flex-1 relative rounded-[20px] bg-white px-5 h-[60px] flex flex-col justify-center gap-1 shadow-sm ring-1 ring-primary/10 group cursor-pointer transition-all hover:ring-primary/50"
+            >
+              <p class="text-xs font-bold leading-tight text-primary/70">目的地</p>
+              <div class="relative">
+                <input
+                  v-model="keyword"
+                  class="w-full bg-transparent outline-none appearance-none cursor-pointer pr-8 text-base text-black truncate transition-colors"
+                  type="text"
+                  placeholder="想住哪～"
+                />
               </div>
+            </label>
 
-              <div class="relative flex-1 flex" ref="peoplePickerRef">
-                <div
-                  @click="togglePicker('people')"
-                  class="w-full h-[60px] rounded-[20px] bg-white px-5 flex flex-col justify-center gap-1 shadow-sm ring-1 ring-primary/10 transition-all hover:ring-accent/50 cursor-pointer"
-                  :class="{ 'ring-accent/50': activePicker === 'people' }"
-                >
-                  <p class="text-xs font-bold leading-tight text-primary/70">人數、需求</p>
-                  <div class="flex items-center justify-between pointer-events-none">
-                    <span class="text-base text-black truncate">{{ peopleDisplayText }}</span>
-                    <svg
-                      class="h-4 w-4 text-primary/40 transition-transform duration-300"
-                      :class="{ 'rotate-180': activePicker === 'people' }"
-                      fill="none"
-                      stroke="currentColor"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        stroke-linecap="round"
-                        stroke-linejoin="round"
-                        stroke-width="2"
-                        d="M19 9l-7 7-7-7"
-                      />
-                    </svg>
-                  </div>
-                </div>
-
-                <transition name="fade">
+            <div class="relative flex h-[60px] md:flex-[1.2]">
+              <VueDatePicker
+                v-model="range"
+                range
+                :min-range="1"
+                :enable-time-picker="false"
+                format="yyyy-MM-dd"
+                :min-date="new Date()"
+                auto-apply
+                hide-input-icon
+                :clearable="false"
+                class="w-full h-full"
+                @update:model-value="handleDateChange"
+                @open="activePicker = 'date'"
+                @closed="activePicker = 'none'"
+              >
+                <template #dp-input>
                   <div
-                    v-if="activePicker === 'people'"
-                    @click.stop
-                    class="absolute top-[calc(100%+12px)] left-0 md:right-0 md:left-auto z-[100] w-full md:w-[300px] rounded-[24px] bg-white p-6 border border-gray-300 shadow-[0px_8px_24px_rgba(0,0,0,0.08)] space-y-6"
+                    class="w-full h-full rounded-[20px] bg-white px-5 flex flex-col justify-center gap-1 shadow-sm ring-1 ring-primary/10 transition-all hover:ring-accent/50 cursor-pointer"
+                    :class="{ 'ring-accent/50': activePicker === 'date' }"
                   >
-                    <div class="flex items-center justify-between">
-                      <div>
-                        <p class="text-sm font-bold text-primary">房間</p>
-                        <p class="text-sm text-gray-400">所需的客房數量</p>
-                      </div>
-                      <div class="flex items-center gap-4">
-                        <button
-                          @click.stop="peopleConfig.rooms > 1 ? peopleConfig.rooms-- : null"
-                          type="button"
-                          class="w-10 h-10 rounded-full border border-slate-200 flex items-center justify-center hover:bg-slate-50"
-                        >
-                          -
-                        </button>
-                        <span class="text-sm font-bold w-4 text-center">{{
-                          peopleConfig.rooms
-                        }}</span>
-                        <button
-                          @click.stop="peopleConfig.rooms++"
-                          type="button"
-                          class="w-10 h-10 rounded-full border border-slate-200 flex items-center justify-center hover:bg-slate-50"
-                        >
-                          +
-                        </button>
-                      </div>
+                    <p class="text-xs font-bold leading-tight text-primary/70">入住 - 退房日期</p>
+                    <input
+                      :value="formatRangeDisplay()"
+                      class="w-full bg-transparent text-sm md:text-base text-black outline-none pointer-events-none"
+                      placeholder="點選選擇日期"
+                      readonly
+                    />
+                  </div>
+                </template>
+              </VueDatePicker>
+            </div>
+
+            <div class="relative flex-1 flex" ref="peoplePickerRef">
+              <div
+                @click="togglePicker('people')"
+                class="w-full h-[60px] rounded-[20px] bg-white px-5 flex flex-col justify-center gap-1 shadow-sm ring-1 ring-primary/10 transition-all hover:ring-accent/50 cursor-pointer"
+                :class="{ 'ring-accent/50': activePicker === 'people' }"
+              >
+                <p class="text-xs font-bold leading-tight text-primary/70">人數、需求</p>
+                <div class="flex items-center justify-between pointer-events-none">
+                  <span class="text-base text-black truncate">{{ peopleDisplayText }}</span>
+                  <svg
+                    class="h-4 w-4 text-primary/40 transition-transform duration-300"
+                    :class="{ 'rotate-180': activePicker === 'people' }"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      stroke-width="2"
+                      d="M19 9l-7 7-7-7"
+                    />
+                  </svg>
+                </div>
+              </div>
+
+              <transition name="fade">
+                <div
+                  v-if="activePicker === 'people'"
+                  @click.stop
+                  class="absolute top-[calc(100%+12px)] left-0 md:right-0 md:left-auto z-[100] w-full md:w-[300px] rounded-[24px] bg-white p-6 border border-gray-300 shadow-[0px_8px_24px_rgba(0,0,0,0.08)] space-y-6"
+                >
+                  <div class="flex items-center justify-between">
+                    <div>
+                      <p class="text-sm font-bold text-primary">房間</p>
+                      <p class="text-sm text-gray-400">所需的客房數量</p>
                     </div>
-                    <div class="flex items-center justify-between">
-                      <div>
-                        <p class="text-sm font-bold text-primary">旅客</p>
-                        <p class="text-sm text-gray-400">總人數</p>
-                      </div>
-                      <div class="flex items-center gap-4">
-                        <button
-                          @click.stop="peopleConfig.people > 1 ? peopleConfig.people-- : null"
-                          type="button"
-                          class="w-10 h-10 rounded-full border border-slate-200 flex items-center justify-center hover:bg-slate-50"
-                        >
-                          -
-                        </button>
-                        <span class="text-sm font-bold w-4 text-center">{{
-                          peopleConfig.people
-                        }}</span>
-                        <button
-                          @click.stop="peopleConfig.people++"
-                          type="button"
-                          class="w-10 h-10 rounded-full border border-slate-200 flex items-center justify-center hover:bg-slate-50"
-                        >
-                          +
-                        </button>
-                      </div>
+                    <div class="flex items-center gap-4">
+                      <button
+                        @click.stop="peopleConfig.rooms > 1 ? peopleConfig.rooms-- : null"
+                        type="button"
+                        class="w-10 h-10 rounded-full border border-slate-200 flex items-center justify-center hover:bg-slate-50"
+                      >
+                        -
+                      </button>
+                      <span class="text-sm font-bold w-4 text-center">{{
+                        peopleConfig.rooms
+                      }}</span>
+                      <button
+                        @click.stop="peopleConfig.rooms++"
+                        type="button"
+                        class="w-10 h-10 rounded-full border border-slate-200 flex items-center justify-center hover:bg-slate-50"
+                      >
+                        +
+                      </button>
                     </div>
                   </div>
-                </transition>
-              </div>
-              <button
-                @click="fetchHotels"
-                class="w-full md:w-[60px] h-[60px] flex items-center justify-center rounded-full bg-primary hover:bg-main border border-white/20 shadow-md text-white transition-all"
-              >
-                <font-awesome-icon icon="search" class="text-xl"/>
-              </button>
+                  <div class="flex items-center justify-between">
+                    <div>
+                      <p class="text-sm font-bold text-primary">旅客</p>
+                      <p class="text-sm text-gray-400">總人數</p>
+                    </div>
+                    <div class="flex items-center gap-4">
+                      <button
+                        @click.stop="peopleConfig.people > 1 ? peopleConfig.people-- : null"
+                        type="button"
+                        class="w-10 h-10 rounded-full border border-slate-200 flex items-center justify-center hover:bg-slate-50"
+                      >
+                        -
+                      </button>
+                      <span class="text-sm font-bold w-4 text-center">{{
+                        peopleConfig.people
+                      }}</span>
+                      <button
+                        @click.stop="peopleConfig.people++"
+                        type="button"
+                        class="w-10 h-10 rounded-full border border-slate-200 flex items-center justify-center hover:bg-slate-50"
+                      >
+                        +
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              </transition>
             </div>
+            <button
+              @click="fetchHotels"
+              class="w-full md:w-[60px] h-[60px] flex items-center justify-center rounded-full bg-primary hover:bg-main border border-white/20 shadow-md text-white transition-all"
+            >
+              <font-awesome-icon icon="search" class="text-xl" />
+            </button>
           </div>
         </div>
+      </div>
     </header>
     <!-- 地圖 -->
     <div class="absolute inset-0 bg-[#e5e3df] z-0 overflow-hidden">
@@ -220,7 +220,9 @@
       :class="[
         'fixed bg-white z-20 shadow-xl transition-all duration-500 ease-in-out flex flex-col self-start my-2.5 ml-5 rounded-[20px] rounded-tr-none',
         isListOpen ? 'translate-x-0' : '-translate-x-[calc(100%+20px)]',
-        isMobileSearchOpen ? 'top-[490px] h-[calc(100vh-510px)] md:top-[165px] md:h-[calc(100vh-190px)]' : 'top-[145px] h-[calc(100vh-170px)] md:top-[165px] md:h-[calc(100vh-190px)]'
+        isMobileSearchOpen
+          ? 'top-[490px] h-[calc(100vh-510px)] md:top-[165px] md:h-[calc(100vh-190px)]'
+          : 'top-[145px] h-[calc(100vh-170px)] md:top-[165px] md:h-[calc(100vh-190px)]',
       ]"
       class="w-[60vw] md:w-[400px]"
     >
@@ -406,7 +408,6 @@
 import { reactive, ref, shallowRef, watch, computed, onMounted, onUnmounted } from 'vue'
 import { VueDatePicker } from '@vuepic/vue-datepicker'
 import '@vuepic/vue-datepicker/dist/main.css'
-import 'v-calendar/style.css'
 import { useRouter } from 'vue-router'
 import { useRoute } from 'vue-router'
 import axios from 'axios'
@@ -608,8 +609,6 @@ const toggleMapType = () => {
   mapInstance.value.setMapTypeId(newType)
   currentMapType.value = newType
 }
-
-
 
 const expandedMenus = ref<string[]>([]) // 儲存哪些 option 已展開
 

--- a/src/views/ticket/TicketDetail.vue
+++ b/src/views/ticket/TicketDetail.vue
@@ -252,7 +252,7 @@
             >
               <div class="h-32 bg-dark_100 overflow-hidden">
                 <img
-                  :src="recommend.imageUrl"
+                  :src="recommend.image_url"
                   :alt="recommend.name"
                   class="w-full h-full object-cover group-hover:scale-110 transition-transform duration-500"
                 />
@@ -263,7 +263,9 @@
                 >
                   {{ recommend.name }}
                 </div>
-                <div class="text-xs text-dark_700 font-medium">TWD {{ recommend.price }} 起</div>
+                <div class="text-xs text-dark_700 font-medium">
+                  TWD {{ Math.floor(recommend.price).toLocaleString() }} 起
+                </div>
               </div>
             </RouterLink>
           </div>
@@ -305,11 +307,11 @@
             </div>
             <div class="flex flex-col items-start">
               <span v-if="displayPrice > 0" class="text-base text-dark_500 line-through">
-                TWD {{ (displayPrice * 1.5).toLocaleString() }}
+                TWD {{ Math.floor(displayPrice * 1.5).toLocaleString() }}
               </span>
               <div class="flex items-end gap-2">
                 <span class="text-2xl font-bold text-red-500">
-                  TWD {{ displayPrice.toLocaleString() }}
+                  TWD {{ Math.floor(displayPrice).toLocaleString() }}
                 </span>
                 <span v-if="totalPrice === 0" class="text-base text-dark_500 mb-0.5">起</span>
               </div>
@@ -317,7 +319,7 @@
           </div>
 
           <!-- Controls: Date, Plans, and Button -->
-          <div v-if="totalPrice === 0" class="mt-3">
+          <div v-if="displayPrice === 0 && tickets.length > 0" class="mt-3">
             <div class="w-full rounded-[10px] border border-gray-300 bg-main_100 p-4 text-dark">
               <div class="font-bold text-sm">此地點為免費入場</div>
               <div class="text-sm text-dark_600 mt-2">無需選擇日期與方案，可直接前往。</div>
@@ -368,7 +370,9 @@
                     >
                       <div class="flex flex-col min-w-0">
                         <span class="font-bold text-dark text-sm truncate">{{ t.name }}</span>
-                        <span class="text-xs text-dark_500 font-medium">NT$ {{ t.price }}</span>
+                        <span class="text-xs text-dark_500 font-medium"
+                          >NT$ {{ Math.floor(t.price).toLocaleString() }}</span
+                        >
                       </div>
                       <div class="flex items-center gap-3 shrink-0">
                         <button
@@ -584,9 +588,9 @@ onMounted(() => {
 interface TicketItem {
   id: number | string
   name: string
-  imageUrl: string
+  image_url: string
   price: number
-  venue: string
+  city: string
   category: string
   date: string
   address: string

--- a/src/views/ticket/TicketDetail.vue
+++ b/src/views/ticket/TicketDetail.vue
@@ -111,10 +111,8 @@
             />
             <div
               v-if="!loading"
-              class="absolute inset-0 bg-black/30 flex items-center justify-center text-white font-bold cursor-pointer transition-all hover:bg-black/40 z-20"
-            >
-              查看全部照片
-            </div>
+              class="absolute inset-0 flex items-center justify-center text-white font-bold transition-all z-0"
+            ></div>
           </div>
         </div>
       </div>
@@ -295,27 +293,25 @@
                   fill="none"
                   stroke="currentColor"
                   viewBox="0 0 24 24"
-              >
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
-              </svg>
-            </button>
+                >
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    d="M19 9l-7 7-7-7"
+                  />
+                </svg>
+              </button>
             </div>
             <div class="flex flex-col items-start">
-              <span
-                v-if="displayPrice > 0"
-                class="text-base text-dark_500 line-through"
-              >
+              <span v-if="displayPrice > 0" class="text-base text-dark_500 line-through">
                 TWD {{ (displayPrice * 1.5).toLocaleString() }}
               </span>
               <div class="flex items-end gap-2">
                 <span class="text-2xl font-bold text-red-500">
                   TWD {{ displayPrice.toLocaleString() }}
                 </span>
-                <span
-                  v-if="totalPrice === 0"
-                  class="text-base text-dark_500 mb-0.5"
-                  >起</span
-                >
+                <span v-if="totalPrice === 0" class="text-base text-dark_500 mb-0.5">起</span>
               </div>
             </div>
           </div>
@@ -330,50 +326,63 @@
             leave-to-class="opacity-0 max-h-0 overflow-hidden"
           >
             <div v-show="isBookingExpanded" class="flex flex-col gap-3 lg:!gap-5 lg:!block">
-            <DatePicker v-model="selectedDate" color="teal" :masks="{ input: 'YYYY-MM-DD' }">
-              <template #default="{ inputValue, inputEvents }">
-                <div
-                  class="p-3 w-full border rounded-[10px] hover:border-primary cursor-pointer transition flex flex-col justify-center"
-                  v-on="inputEvents"
-                >
-                  <div class="text-xs text-dark_700 mb-1 font-bold">選擇日期</div>
-                  <div class="font-medium text-dark text-sm">{{ inputValue || '請選擇日期' }}</div>
-                </div>
-              </template>
-            </DatePicker>
-
-            <div class="relative group mt-0 lg:mt-2">
-              <div class="w-full border rounded-[10px] transition hover:border-primary p-4">
-                <div class="text-xs text-dark_700 mb-3 font-bold">選擇方案</div>
-
-                <div v-if="tickets.length === 0" class="text-sm text-dark_500">目前無可用方案</div>
-
-                <div v-else class="space-y-4">
-                  <div v-for="t in tickets" :key="t.id" class="flex items-center justify-between gap-4">
-                    <div class="flex flex-col min-w-0">
-                      <span class="font-bold text-dark text-sm truncate">{{ t.name }}</span>
-                      <span class="text-xs text-dark_500 font-medium">NT$ {{ t.price }}</span>
+              <DatePicker
+                v-model="selectedDate"
+                :min-date="minDate"
+                color="teal"
+                :masks="{ input: 'YYYY-MM-DD' }"
+              >
+                <template #default="{ inputValue, inputEvents }">
+                  <div
+                    class="p-3 w-full border rounded-[10px] hover:border-primary cursor-pointer transition flex flex-col justify-center"
+                    v-on="inputEvents"
+                  >
+                    <div class="text-xs text-dark_700 mb-1 font-bold">選擇日期</div>
+                    <div class="font-medium text-dark text-sm">
+                      {{ inputValue || '請選擇日期' }}
                     </div>
-                    <div class="flex items-center gap-3 shrink-0">
-                      <button
-                        @click="decreaseQuantity(t.id)"
-                        class="w-10 h-10 rounded-full border border-gray-300 flex items-center justify-center text-dark_500 hover:bg-gray-100 disabled:opacity-50 transition"
-                        :disabled="t.quantity <= 0"
-                      >
-                        -
-                      </button>
-                      <span class="w-4 text-center text-sm font-bold">{{ t.quantity }}</span>
-                      <button
-                        @click="increaseQuantity(t.id)"
-                        class="w-10 h-10 rounded-full border border-gray-300 flex items-center justify-center text-dark_500 hover:bg-gray-100 transition"
-                      >
-                        +
-                      </button>
+                  </div>
+                </template>
+              </DatePicker>
+
+              <div class="relative group mt-0 lg:mt-2">
+                <div class="w-full border rounded-[10px] transition hover:border-primary p-4">
+                  <div class="text-xs text-dark_700 mb-3 font-bold">選擇方案</div>
+
+                  <div v-if="tickets.length === 0" class="text-sm text-dark_500">
+                    目前無可用方案
+                  </div>
+
+                  <div v-else class="space-y-4">
+                    <div
+                      v-for="t in tickets"
+                      :key="t.id"
+                      class="flex items-center justify-between gap-4"
+                    >
+                      <div class="flex flex-col min-w-0">
+                        <span class="font-bold text-dark text-sm truncate">{{ t.name }}</span>
+                        <span class="text-xs text-dark_500 font-medium">NT$ {{ t.price }}</span>
+                      </div>
+                      <div class="flex items-center gap-3 shrink-0">
+                        <button
+                          @click="decreaseQuantity(t.id)"
+                          class="w-10 h-10 rounded-full border border-gray-300 flex items-center justify-center text-dark_500 hover:bg-gray-100 disabled:opacity-50 transition"
+                          :disabled="t.quantity <= 0"
+                        >
+                          -
+                        </button>
+                        <span class="w-4 text-center text-sm font-bold">{{ t.quantity }}</span>
+                        <button
+                          @click="increaseQuantity(t.id)"
+                          class="w-10 h-10 rounded-full border border-gray-300 flex items-center justify-center text-dark_500 hover:bg-gray-100 transition"
+                        >
+                          +
+                        </button>
+                      </div>
                     </div>
                   </div>
                 </div>
               </div>
-            </div>
             </div>
           </Transition>
 
@@ -419,6 +428,8 @@ interface TicketWithQuantity extends Ticket {
 
 const tickets = ref<TicketWithQuantity[]>([])
 const selectedDate = ref<Date>(new Date())
+const minDate = new Date()
+minDate.setHours(0, 0, 0, 0)
 const isBookingExpanded = ref<boolean>(false)
 
 // Image loading tracking
@@ -577,9 +588,6 @@ interface TicketItem {
 }
 
 // Ensure AttractionWithImages interface is available if needed, though backend returns flattened structure for recommendations
-interface AttractionWithImages extends Attraction {
-  attraction_images: { image_url: string }[]
-}
 
 function handleBooking() {
   // Auto-expand if collapsed on mobile/tablet
@@ -604,10 +612,9 @@ function onSearch() {
     return
   }
 
-  const dateStr = format(selectedDate.value, 'yyyy/MM/dd')
-
   // Aggregate selection
   const subtitle = selectedTickets.map((t) => `${t.name} x${t.quantity}`).join(', ')
+  const dateStr = format(selectedDate.value, 'yyyy/MM/dd')
 
   // Total price is already computed in totalPrice
 

--- a/src/views/ticket/TicketDetail.vue
+++ b/src/views/ticket/TicketDetail.vue
@@ -317,7 +317,14 @@
           </div>
 
           <!-- Controls: Date, Plans, and Button -->
+          <div v-if="totalPrice === 0" class="mt-3">
+            <div class="w-full rounded-[10px] border border-gray-300 bg-main_100 p-4 text-dark">
+              <div class="font-bold text-sm">此地點為免費入場</div>
+              <div class="text-sm text-dark_600 mt-2">無需選擇日期與方案，可直接前往。</div>
+            </div>
+          </div>
           <Transition
+            v-else
             enter-active-class="transition-all duration-1000 ease-out"
             leave-active-class="transition-all duration-800 ease-in"
             enter-from-class="opacity-0 max-h-0 overflow-hidden"
@@ -386,7 +393,7 @@
             </div>
           </Transition>
 
-          <div class="pt-2">
+          <div v-if="totalPrice > 0" class="pt-2">
             <button
               type="submit"
               @click="handleBooking"

--- a/src/views/ticket/TicketHomeView.vue
+++ b/src/views/ticket/TicketHomeView.vue
@@ -174,7 +174,6 @@ watch(
 )
 
 function onSearch() {
-  console.log('[Ticket Search Submit]', { tab: activeTab.value, ...form, ...peopleConfig })
   router.push({
     path: '/tickets/search',
     query: {
@@ -217,11 +216,10 @@ const ticketClassify = [
   },
 ]
 
-const handleWishlist = (id: number | string) => console.log('收藏門票 ID:', id)
-const handleBook = (id: number | string) => console.log('購票 ID:', id)
+const handleWishlist = (id: number | string) => {}
+const handleBook = (id: number | string) => {}
 
 function onClickRegion(tc: { label: string }) {
-  console.log('Category clicked:', tc)
   router.push({ path: '/tickets/search', query: { category: tc.label } })
 }
 </script>

--- a/src/views/ticket/TicketHomeView.vue
+++ b/src/views/ticket/TicketHomeView.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import { reactive, ref, watch, onMounted, onUnmounted, computed } from 'vue'
-import 'v-calendar/style.css'
 import { useRouter } from 'vue-router'
 import HomePageTicketCard from '@/components/layout/HomePageTicketCard.vue'
 import axios from 'axios'

--- a/src/views/ticket/TicketSearch.vue
+++ b/src/views/ticket/TicketSearch.vue
@@ -146,16 +146,24 @@ const applyClientSideFilters = () => {
 
   // Rating Filter (Placeholder logic for now, as backend doesn't seem to support it yet or it was client side)
   const selectedRatings = ticketFiltered.find((m) => m.key === 'ratings')?.selected ?? []
+
   if (selectedRatings.length > 0) {
-    // Simple logic: if '4.5 +' selected, show > 4.5
-    const minRating = selectedRatings.includes('4.5 +')
-      ? 4.5
-      : selectedRatings.includes('4.0')
-        ? 4.0
-        : 0
-    if (minRating > 0) {
-      result = result.filter((item) => (item.rating || 0) >= minRating)
-    }
+    result = result.filter((item) => {
+      const rating = item.rating ?? 0
+
+      return selectedRatings.some((range) => {
+        switch (range) {
+          case '4.5+':
+            return rating >= 4.5
+          case '4.0-4.5':
+            return rating >= 4.0 && rating < 4.5
+          case '3.5-4.0':
+            return rating >= 3.5 && rating < 4.0
+          default:
+            return true
+        }
+      })
+    })
   }
 
   // Availability Filter
@@ -253,7 +261,7 @@ const ticketFiltered = reactive<FilterMenu[]>([
   {
     key: 'ratings',
     title: '景點評分',
-    options: ['4.5 +', '4.0'],
+    options: ['4.5+', '4.0-4.5', '3.5-4.0'],
     selected: [],
   },
   {

--- a/src/views/ticket/TicketSearch.vue
+++ b/src/views/ticket/TicketSearch.vue
@@ -28,7 +28,14 @@ interface FilterMenu {
   selected: string[]
 }
 
+const isAutoCleaningUrl = ref(false)
+
 const fetchAttractions = async (): Promise<void> => {
+  if (isAutoCleaningUrl.value) {
+    isAutoCleaningUrl.value = false
+    return
+  }
+
   loading.value = true
   errorMsg.value = ''
 
@@ -48,7 +55,29 @@ const fetchAttractions = async (): Promise<void> => {
       params.city = city
     }
 
-    if (category) params.category = category
+    if (category) {
+      params.category = category
+      // Sync UI state with URL param if not already synced
+      const categoryMenu = ticketFiltered.find((m) => m.key === 'categories')
+      if (categoryMenu && !categoryMenu.selected.includes(category)) {
+        categoryMenu.selected = [category]
+      }
+    }
+
+    // Auto-clean URL logic for filters (category, cities, city/destination)
+    if (category || cities || (city && city !== '選擇城市' && city !== '全部城市')) {
+      const newQuery = { ...route.query }
+      if (category) delete newQuery.category
+      if (cities) delete newQuery.cities
+      if (city) {
+        delete newQuery.city
+        delete newQuery.destination
+      }
+
+      isAutoCleaningUrl.value = true
+      router.replace({ path: '/tickets/search', query: newQuery })
+    }
+    // Removed else block that forced clearing UI, allowing state to persist during auto-clean
 
     // Note: We do NOT send districts to backend, so we get all data for the city/keyword.
     // We filter districts client-side to ensure sidebar options reflect available data.
@@ -235,22 +264,13 @@ const ticketFiltered = reactive<FilterMenu[]>([
   },
 ])
 
+// Removed redundant watcher for route.query.category as it is handled in fetchAttractions
+/*
 watch(
   () => route.query.category,
-  (newCategory) => {
-    if (newCategory) {
-      const categoryMenu = ticketFiltered.find((m) => m.key === 'categories')
-      if (categoryMenu) {
-        if (!categoryMenu.selected.includes(newCategory as string)) {
-          if (categoryMenu.options.includes(newCategory as string)) {
-            categoryMenu.selected = [newCategory as string]
-          }
-        }
-      }
-    }
-  },
-  { immediate: true },
+  ...
 )
+*/
 
 watch(
   ticketFiltered,
@@ -288,8 +308,17 @@ function onLocalSearch() {
 }
 
 function clearOptions(key: string) {
-  const menu = ticketFiltered.find((m) => m.key === key)
-  if (menu) menu.selected = []
+  const index = ticketFiltered.findIndex((m) => m.key === key)
+  if (index !== -1) {
+    ticketFiltered[index].selected = []
+  }
+
+  // Sync URL for categories
+  if (key === 'categories') {
+    const newQuery = { ...route.query }
+    delete newQuery.category
+    router.push({ path: '/tickets/search', query: newQuery })
+  }
 }
 
 function toggleExpandMenu(title: string) {
@@ -381,7 +410,7 @@ function toggleExpandMenu(title: string) {
                 <div class="flex justify-between items-center mb-2">
                   <h4 class="font-medium text-base text-dark">{{ TicketMenu.title }}</h4>
                   <button
-                    @click="TicketMenu.selected = []"
+                    @click="clearOptions(TicketMenu.key)"
                     :disabled="TicketMenu.selected.length === 0"
                     class="text-xs text-gray-400 hover:text-primary transition-colors duration-200 disabled:opacity-50 disabled:cursor-not-allowed"
                   >
@@ -512,7 +541,9 @@ function toggleExpandMenu(title: string) {
             >
               <div class="flex items-center justify-between mb-6">
                 <h3 class="font-bold text-xl text-dark">篩選條件</h3>
-                <button @click="isFilterDrawerOpen = false" class="text-dark_500 text-2xl">&times;</button>
+                <button @click="isFilterDrawerOpen = false" class="text-dark_500 text-2xl">
+                  &times;
+                </button>
               </div>
 
               <div class="flex flex-col gap-6">

--- a/src/views/ticket/TicketSearch.vue
+++ b/src/views/ticket/TicketSearch.vue
@@ -316,9 +316,9 @@ function onLocalSearch() {
 }
 
 function clearOptions(key: string) {
-  const index = ticketFiltered.findIndex((m) => m.key === key)
-  if (index !== -1) {
-    ticketFiltered[index].selected = []
+  const item = ticketFiltered.find((m) => m.key === key)
+  if (item) {
+    item.selected = []
   }
 
   // Sync URL for categories

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -1,6 +1,6 @@
 {
   "extends": "@vue/tsconfig/tsconfig.dom.json",
-  "include": ["env.d.ts", "src/**/*", "src/**/*.vue"],
+  "include": ["env.d.ts", "src/**/*.vue"],
   "exclude": ["src/**/__tests__/*"],
   "compilerOptions": {
     "module": "esnext",


### PR DESCRIPTION
修改體驗頁面：

1. 訂購時不能選過去的日期
2. 評分篩選功能
3. 修改免費商品的預定頁資訊， 並取消預訂按鈕的顯示
4. 在搜尋結果頁重新整理或是點選清除按鈕，會清空當下篩選資訊

庫存還沒解決:(

<img width="1150" height="2275" alt="image" src="https://github.com/user-attachments/assets/7adea3b1-8210-48aa-8d3c-7a3d417641e9" />
